### PR TITLE
Test if continuous integration is faulty

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: 1
+          version: 1.10.0
       - uses: actions/cache@v1
         env:
           cache-name: cache-artifacts


### PR DESCRIPTION
Continuous integration builds began failing due to Julia errors. I suspected that this did not have to do with actual code in the pipeline, but with some update to julia versions behind the scenes, resulting in package incompatibilities when creating the julia environment during testing. To test this, I created a branch from main, added an empty file and opened a pul request to initiate continuous integration tests. 